### PR TITLE
[TI-31156] Exchange deprecated toUpperCase with uppercase

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,2 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
-
-npx commitlint --edit "$1"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.0.2]
+
+### Bug Fixes
+
+-   Replace deprecated `toUpperCase(Locale)` with `uppercase(Locale)` to avoid Kotlin compilation failures on newer toolchains
+
 ### [0.9.6](https://github.com/timbru31/cordova-plugin-lottie-splashscreen/compare/v0.9.5...v0.9.6) (2021-03-04)
 
 ### Bug Fixes

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,0 @@
-module.exports = { extends: ['@commitlint/config-angular'] };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@thing-it/cordova-plugin-lottie-splashscreen",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thing-it/cordova-plugin-lottie-splashscreen",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Apache Cordova plugin to show Lottie animations as the splash screen with Airbnb's Lottie wrapper",
   "license": "MIT",
   "types": "./types/index.d.ts",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="cordova-plugin-lottie-splashscreen" version="1.0.1">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="cordova-plugin-lottie-splashscreen" version="1.0.2">
     <name>LottieSplashScreen</name>
     <description>LottieSplashScreen Plugin</description>
     <license>MIT</license>

--- a/src/android/LottieSplashScreen.kt
+++ b/src/android/LottieSplashScreen.kt
@@ -210,7 +210,7 @@ class LottieSplashScreen : CordovaPlugin() {
             preferences.getString(
                 "LottieScaleType",
                 "FIT_CENTER"
-            ).toUpperCase(Locale.ENGLISH)
+            ).uppercase(Locale.ENGLISH)
         )
 
         val color = ColorHelper.parseColor(


### PR DESCRIPTION
- [toUpperCase is deprecated](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.text/to-upper-case.html) and throws errors when using with newer Kotlin versions blocking cordova builds with newer versions